### PR TITLE
Fix popover overflow (closes #9)

### DIFF
--- a/netbox_map/__init__.py
+++ b/netbox_map/__init__.py
@@ -6,7 +6,7 @@ class MapConfig(PluginConfig):
     verbose_name = 'NetBox Map'
     author = 'Christian Rose'
     description = 'Interactive floor plan visualization for NetBox sites'
-    version = '0.4.3'
+    version = '0.4.4'
     base_url = 'map'
     min_version = '4.5.0'
     default_settings = {

--- a/netbox_map/static/netbox_map/css/floorplan.css
+++ b/netbox_map/static/netbox_map/css/floorplan.css
@@ -659,7 +659,7 @@
     position: absolute;
     z-index: 20;
     pointer-events: none;
-    max-width: 280px;
+    max-width: 340px;
     padding: 8px 12px;
     border-radius: 6px;
     font-size: 12px;
@@ -669,11 +669,8 @@
     border: 1px solid var(--fp-border);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
     backdrop-filter: blur(8px);
-    white-space: nowrap;
-}
-.tile-popover.popover-has-trace {
-    max-width: 340px;
     white-space: normal;
+    word-break: break-word;
 }
 
 .tile-popover strong {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-map"
-version = "0.4.3"
+version = "0.4.4"
 description = "Interactive floor plan visualization for NetBox sites"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Popover now wraps long text instead of overflowing out of bounds
- Changed `white-space: nowrap` → `normal` and added `word-break: break-word`
- Unified `max-width` to 340px (removed separate `.popover-has-trace` override since it's no longer needed)
- Bumped version to 0.4.4

Closes #9