### PR TITLE
Add drop tile type for network port assignments (closes #11)

### DIFF
--- a/netbox_map/__init__.py
+++ b/netbox_map/__init__.py
@@ -6,7 +6,7 @@ class MapConfig(PluginConfig):
     verbose_name = 'NetBox Map'
     author = 'Christian Rose'
     description = 'Interactive floor plan visualization for NetBox sites'
-    version = '0.4.4'
+    version = '0.5.0'
     base_url = 'map'
     min_version = '4.5.0'
     default_settings = {

--- a/netbox_map/api/serializers.py
+++ b/netbox_map/api/serializers.py
@@ -7,7 +7,7 @@ from netbox.api.fields import ContentTypeField
 from netbox.api.serializers import NetBoxModelSerializer
 from utilities.api import get_serializer_for_model
 from ..choices import BUILTIN_TYPE_SLUGS
-from ..models import FloorPlan, FloorPlanTile, CustomMarkerType, LocationCoordinates, MapMarker
+from ..models import FloorPlan, FloorPlanTile, CustomMarkerType, LocationCoordinates, MapMarker, TilePortAssignment
 
 
 class CustomMarkerTypeSerializer(NetBoxModelSerializer):
@@ -95,6 +95,30 @@ class FloorPlanTileSerializer(NetBoxModelSerializer):
 
     def validate_tile_type(self, value):
         return _validate_type_slug(value)
+
+
+class TilePortAssignmentSerializer(NetBoxModelSerializer):
+    port_type = ContentTypeField(
+        queryset=ContentType.objects.filter(
+            app_label='dcim',
+            model__in=['frontport', 'rearport'],
+        ),
+    )
+    port = serializers.SerializerMethodField(read_only=True)
+
+    class Meta:
+        model = TilePortAssignment
+        fields = [
+            'id', 'display',
+            'tile', 'port_type', 'port_id', 'port',
+            'tags', 'custom_fields', 'created', 'last_updated',
+        ]
+        brief_fields = ('id', 'display', 'port_type', 'port_id')
+
+    def get_port(self, obj):
+        if obj.port is not None:
+            return {'display': str(obj.port)}
+        return None
 
 
 class LocationCoordinatesSerializer(NetBoxModelSerializer):

--- a/netbox_map/api/urls.py
+++ b/netbox_map/api/urls.py
@@ -6,6 +6,7 @@ router.register('custom-marker-types', views.CustomMarkerTypeViewSet)
 router.register('floorplans', views.FloorPlanViewSet)
 router.register('floorplan-tiles', views.FloorPlanTileViewSet)
 router.register('location-coordinates', views.LocationCoordinatesViewSet)
+router.register('tile-port-assignments', views.TilePortAssignmentViewSet)
 router.register('map-markers', views.MapMarkerViewSet)
 
 urlpatterns = router.urls

--- a/netbox_map/api/views.py
+++ b/netbox_map/api/views.py
@@ -1,9 +1,11 @@
+from django.contrib.contenttypes.prefetch import GenericPrefetch
+from dcim.models import FrontPort, RearPort
 from netbox.api.viewsets import NetBoxModelViewSet
 from .. import filtersets
-from ..models import FloorPlan, FloorPlanTile, CustomMarkerType, LocationCoordinates, MapMarker
+from ..models import FloorPlan, FloorPlanTile, CustomMarkerType, LocationCoordinates, MapMarker, TilePortAssignment
 from .serializers import (
     FloorPlanSerializer, FloorPlanTileSerializer, CustomMarkerTypeSerializer,
-    LocationCoordinatesSerializer, MapMarkerSerializer,
+    LocationCoordinatesSerializer, MapMarkerSerializer, TilePortAssignmentSerializer,
 )
 
 
@@ -28,6 +30,14 @@ class FloorPlanTileViewSet(NetBoxModelViewSet):
 class LocationCoordinatesViewSet(NetBoxModelViewSet):
     queryset = LocationCoordinates.objects.select_related('location__site')
     serializer_class = LocationCoordinatesSerializer
+
+
+class TilePortAssignmentViewSet(NetBoxModelViewSet):
+    queryset = TilePortAssignment.objects.select_related('tile', 'port_type').prefetch_related(
+        GenericPrefetch('port', [FrontPort.objects.all(), RearPort.objects.all()])
+    )
+    serializer_class = TilePortAssignmentSerializer
+    filterset_class = filtersets.TilePortAssignmentFilterSet
 
 
 class MapMarkerViewSet(NetBoxModelViewSet):

--- a/netbox_map/choices.py
+++ b/netbox_map/choices.py
@@ -16,6 +16,7 @@ class FloorPlanTileTypeChoices(ChoiceSet):
     TYPE_CAMERA = 'camera'
     TYPE_PRINTER = 'printer'
     TYPE_FLOORPLAN_LINK = 'floorplan_link'
+    TYPE_DROP = 'drop'
 
     CHOICES = [
         (TYPE_RACK, _('Rack'), 'blue'),
@@ -31,6 +32,7 @@ class FloorPlanTileTypeChoices(ChoiceSet):
         (TYPE_CAMERA, _('Camera'), 'red'),
         (TYPE_PRINTER, _('Printer'), 'orange'),
         (TYPE_FLOORPLAN_LINK, _('Floor Plan Link'), 'indigo'),
+        (TYPE_DROP, _('Drop'), 'green'),
     ]
 
 
@@ -62,6 +64,7 @@ BUILTIN_TYPE_CONFIG = {
     'camera':         {'name': 'Camera',          'color': '#c42020', 'icon': 'mdi-cctv'},
     'printer':        {'name': 'Printer',         'color': '#e67e22', 'icon': 'mdi-printer'},
     'floorplan_link': {'name': 'Floor Plan Link', 'color': '#4a50c8', 'icon': 'mdi-floor-plan'},
+    'drop':           {'name': 'Drop',            'color': '#2ecc71', 'icon': 'mdi-ethernet'},
 }
 
 # Set of all built-in slugs for quick lookup

--- a/netbox_map/filtersets.py
+++ b/netbox_map/filtersets.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 from dcim.models import Site, Location
 from netbox.filtersets import NetBoxModelFilterSet
-from .models import FloorPlan, FloorPlanTile, CustomMarkerType, MapMarker
+from .models import FloorPlan, FloorPlanTile, CustomMarkerType, MapMarker, TilePortAssignment
 from .choices import FloorPlanTileStatusChoices, get_all_tile_type_choices
 
 
@@ -73,6 +73,20 @@ class CustomMarkerTypeFilterSet(NetBoxModelFilterSet):
 
     def search(self, queryset, name, value):
         return queryset.filter(name__icontains=value)
+
+
+class TilePortAssignmentFilterSet(NetBoxModelFilterSet):
+    tile_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=FloorPlanTile.objects.all(),
+        label=_('Tile (ID)'),
+    )
+
+    class Meta:
+        model = TilePortAssignment
+        fields = ['id', 'tile_id']
+
+    def search(self, queryset, name, value):
+        return queryset
 
 
 class MapMarkerFilterSet(NetBoxModelFilterSet):

--- a/netbox_map/forms.py
+++ b/netbox_map/forms.py
@@ -358,6 +358,14 @@ class FloorPlanTileForm(NetBoxModelForm):
     def clean(self):
         super().clean()
 
+        tile_type = self.cleaned_data.get('tile_type')
+
+        # Drop tiles use port_assignments, not the single generic FK
+        if tile_type == 'drop':
+            self.cleaned_data['assigned_object_type'] = None
+            self.cleaned_data['assigned_object_id'] = None
+            return self.cleaned_data
+
         assigned_object_type = self.cleaned_data.get('assigned_object_type')
 
         if assigned_object_type:

--- a/netbox_map/migrations/0012_tileportassignment.py
+++ b/netbox_map/migrations/0012_tileportassignment.py
@@ -1,0 +1,55 @@
+import django.db.models.deletion
+from django.db import migrations, models
+import taggit.managers
+import utilities.json
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('netbox_map', '0011_custommarkertype'),
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('extras', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TilePortAssignment',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ('created', models.DateTimeField(auto_now_add=True, null=True)),
+                ('last_updated', models.DateTimeField(auto_now=True, null=True)),
+                ('custom_field_data', models.JSONField(blank=True, default=dict, encoder=utilities.json.CustomFieldJSONEncoder)),
+                ('port_id', models.PositiveBigIntegerField()),
+                ('tile', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='port_assignments',
+                    to='netbox_map.floorplantile',
+                )),
+                ('port_type', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    to='contenttypes.contenttype',
+                )),
+                ('tags', taggit.managers.TaggableManager(through='extras.TaggedItem', to='extras.Tag')),
+            ],
+            options={
+                'verbose_name': 'tile port assignment',
+                'verbose_name_plural': 'tile port assignments',
+                'ordering': ('tile', 'port_type', 'port_id'),
+            },
+        ),
+        migrations.AddConstraint(
+            model_name='tileportassignment',
+            constraint=models.UniqueConstraint(
+                fields=('tile', 'port_type', 'port_id'),
+                name='netbox_map_tileportassignment_unique_tile_port',
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='tileportassignment',
+            index=models.Index(
+                fields=['port_type', 'port_id'],
+                name='netbox_map_tileportass_port_ty_idx',
+            ),
+        ),
+    ]

--- a/netbox_map/models.py
+++ b/netbox_map/models.py
@@ -352,6 +352,49 @@ class FloorPlanTile(NetBoxModel):
         return None
 
 
+class TilePortAssignment(NetBoxModel):
+    """Maps a FloorPlanTile (drop tile) to a FrontPort or RearPort."""
+    tile = models.ForeignKey(
+        to='netbox_map.FloorPlanTile',
+        on_delete=models.CASCADE,
+        related_name='port_assignments',
+    )
+    port_type = models.ForeignKey(
+        to=ContentType,
+        on_delete=models.CASCADE,
+        limit_choices_to={'app_label': 'dcim', 'model__in': ['frontport', 'rearport']},
+    )
+    port_id = models.PositiveBigIntegerField()
+    port = GenericForeignKey(ct_field='port_type', fk_field='port_id')
+
+    class Meta:
+        ordering = ('tile', 'port_type', 'port_id')
+        verbose_name = _('tile port assignment')
+        verbose_name_plural = _('tile port assignments')
+        constraints = (
+            models.UniqueConstraint(
+                fields=('tile', 'port_type', 'port_id'),
+                name='%(app_label)s_%(class)s_unique_tile_port'
+            ),
+        )
+        indexes = [
+            models.Index(fields=['port_type', 'port_id']),
+        ]
+
+    def __str__(self):
+        return f'{self.port} on {self.tile}'
+
+    def get_absolute_url(self):
+        return self.tile.get_absolute_url()
+
+    def clean(self):
+        super().clean()
+        if self.tile_id and self.tile.tile_type != 'drop':
+            raise ValidationError(
+                _('Port assignments can only be added to drop tiles.')
+            )
+
+
 class LocationCoordinates(NetBoxModel):
     """Stores geographic coordinates for a dcim.Location (which lacks lat/lng in core)."""
     location = models.OneToOneField(
@@ -584,5 +627,6 @@ class MapSettings(models.Model):
                     'ap', 'camera', 'printer', 'floorplan_link',
                 ]
             }
+            obj.tile_popover_config['drop'] = ['label', 'cable_trace']
             obj.save()
         return obj

--- a/netbox_map/static/netbox_map/js/floorplan_viewer.js
+++ b/netbox_map/static/netbox_map/js/floorplan_viewer.js
@@ -303,6 +303,20 @@
             ctx.globalAlpha = 1.0;
         }
 
+        // Draw port count on drop tiles
+        if (tile.type === 'drop' && tile.drop_port_count && h > tileSize * 0.8) {
+            var dropFont = tileSize / 4.5;
+            ctx.font = dropFont + 'px -apple-system, "Segoe UI", sans-serif';
+            ctx.globalAlpha = 0.7;
+            ctx.save();
+            ctx.beginPath();
+            ctx.rect(x + gap, y + gap, w - gap * 2, h - gap * 2);
+            ctx.clip();
+            ctx.fillText(tile.drop_port_count + ' port' + (tile.drop_port_count !== 1 ? 's' : ''), centerX, centerY + fontSize * 0.6);
+            ctx.restore();
+            ctx.globalAlpha = 1.0;
+        }
+
         // Draw direction arrow on camera tiles
         if (tile.type === 'camera') {
             var arrowLen = Math.min(w, h) * 0.2;
@@ -545,7 +559,23 @@
         // Fetch enriched detail via AJAX
         var enrichedEl = document.getElementById('fp-enriched-detail');
         if (enrichedEl) {
-            if (tile.object_type_model && tile.object_id) {
+            if (tile.type === 'drop' && tile.id) {
+                // Drop tiles: fetch traces for all assigned ports
+                enrichedEl.innerHTML = '<div class="sidebar-detail-loading">Loading port traces\u2026</div>';
+                fetch(detailBaseUrl + 'drop/' + tile.id + '/')
+                    .then(function(r) {
+                        if (!r.ok) throw new Error('HTTP ' + r.status);
+                        return r.json();
+                    })
+                    .then(function(detail) {
+                        if (selectedTile !== tile) return;
+                        enrichedEl.innerHTML = '';
+                        renderCableTracePanel(detail.interfaces, tile);
+                    })
+                    .catch(function() {
+                        if (selectedTile === tile) enrichedEl.innerHTML = '';
+                    });
+            } else if (tile.object_type_model && tile.object_id) {
                 enrichedEl.innerHTML = '<div class="sidebar-detail-loading">Loading details\u2026</div>';
                 fetch(detailBaseUrl + tile.object_type_model + '/' + tile.object_id + '/')
                     .then(function(r) {
@@ -880,7 +910,9 @@
         panel.classList.remove('d-none');
         if (title) {
             var model = tile.object_type_model;
-            if (model === 'rearport' || model === 'frontport') {
+            if (tile.type === 'drop') {
+                title.textContent = 'Drop Ports (' + interfaces.length + ')';
+            } else if (model === 'rearport' || model === 'frontport') {
                 title.textContent = 'Cable Trace';
             } else {
                 title.textContent = 'Ports (' + interfaces.length + ')';
@@ -1405,9 +1437,10 @@
                     break;
                 case 'cable_trace':
                 case 'cable_trace_full':
-                    // Only for device/rearport/frontport tiles with an object_id
+                    // For device/rearport/frontport tiles with an object_id, or drop tiles
                     var traceModel = tile.object_type_model;
-                    if (traceModel && (traceModel === 'device' || traceModel === 'rearport' || traceModel === 'frontport') && tile.object_id) {
+                    var hasTraceSource = (traceModel && (traceModel === 'device' || traceModel === 'rearport' || traceModel === 'frontport') && tile.object_id) || tile.type === 'drop';
+                    if (hasTraceSource) {
                         if (tile._cachedTrace) {
                             var renderer = (fieldKey === 'cable_trace_full') ? renderPopoverTraceFull : renderPopoverTrace;
                             var traceHtml = renderer(tile._cachedTrace);
@@ -1417,7 +1450,9 @@
                             lines.push('<span class="popover-dim">Cable trace:</span> Loading...');
                             // AJAX fetch cable trace data
                             (function(fetchTile, fetchModel) {
-                                var url = detailBaseUrl + fetchModel + '/' + fetchTile.object_id + '/';
+                                var url = fetchTile.type === 'drop'
+                                    ? detailBaseUrl + 'drop/' + fetchTile.id + '/'
+                                    : detailBaseUrl + fetchModel + '/' + fetchTile.object_id + '/';
                                 fetch(url, { credentials: 'same-origin' })
                                 .then(function(r) { return r.ok ? r.json() : null; })
                                 .then(function(data) {

--- a/netbox_map/templates/netbox_map/floorplan_visualization.html
+++ b/netbox_map/templates/netbox_map/floorplan_visualization.html
@@ -345,6 +345,28 @@
             <div id="link-current" class="small text-muted"></div>
           </div>
         </div>
+
+        {# Drop Ports panel (edit mode, for drop tiles) #}
+        <div id="drop-ports-panel" class="d-none">
+          <div class="sidebar-section-title">{% trans "Drop Ports" %}</div>
+          <div class="sidebar-link-controls">
+            <select id="drop-port-type" class="form-select form-select-sm sidebar-input no-ts">
+              <option value="">-- {% trans "Select Port Type" %} --</option>
+              <option value="dcim.frontport">{% trans "Front Port" %}</option>
+              <option value="dcim.rearport">{% trans "Rear Port" %}</option>
+            </select>
+            <select id="drop-port-select" class="form-select form-select-sm sidebar-input no-ts" disabled>
+              <option value="">-- {% trans "Select port type first" %} --</option>
+            </select>
+            <div class="d-flex gap-1 align-items-center">
+              <button id="add-drop-port-btn" class="btn btn-sm btn-primary" disabled>
+                <i class="mdi mdi-plus"></i> {% trans "Add Port" %}
+              </button>
+              <span id="drop-port-status" class="small text-muted ms-1"></span>
+            </div>
+            <div id="drop-port-list" class="mt-2"></div>
+          </div>
+        </div>
         {% endif %}
       </div>
     </div>
@@ -391,13 +413,13 @@
         linkBtn.disabled = !this.value;
       });
 
-      // Show/hide link panel on tile selection
+      // Show/hide link panel on tile selection (hide for drop tiles)
       document.getElementById('floorplan-canvas').addEventListener('click', function() {
         setTimeout(function() {
           var viewer = window.floorplanViewer;
           if (!viewer) return;
           var tile = viewer.getSelectedTile();
-          if (!tile) {
+          if (!tile || tile.type === 'drop') {
             if (linkPanel) linkPanel.classList.add('d-none');
             return;
           }
@@ -595,6 +617,209 @@
         })
         .catch(function(err) { alert('Network error: ' + err.message); });
       });
+    })();
+
+    // Drop port management logic (for drop tiles)
+    (function() {
+      var container = document.getElementById('floorplan-container');
+      if (!container) return;
+
+      var siteId = container.dataset.siteId;
+      var csrfToken = container.dataset.csrfToken;
+
+      var DROP_API_ENDPOINTS = {
+        'dcim.frontport': '/api/dcim/front-ports/',
+        'dcim.rearport': '/api/dcim/rear-ports/'
+      };
+      var assignmentApiUrl = '/api/plugins/map/tile-port-assignments/';
+
+      var dropPanel = document.getElementById('drop-ports-panel');
+      var portTypeSelect = document.getElementById('drop-port-type');
+      var portSelect = document.getElementById('drop-port-select');
+      var addBtn = document.getElementById('add-drop-port-btn');
+      var statusEl = document.getElementById('drop-port-status');
+      var portListEl = document.getElementById('drop-port-list');
+
+      if (!dropPanel || !portTypeSelect || !portSelect) return;
+
+      // Enable add button when port is selected
+      portSelect.addEventListener('change', function() {
+        addBtn.disabled = !this.value;
+      });
+
+      // Show/hide panel on tile selection
+      document.getElementById('floorplan-canvas').addEventListener('click', function() {
+        setTimeout(function() {
+          var viewer = window.floorplanViewer;
+          if (!viewer) return;
+          var tile = viewer.getSelectedTile();
+          if (!tile || tile.type !== 'drop') {
+            dropPanel.classList.add('d-none');
+            return;
+          }
+          dropPanel.classList.remove('d-none');
+          loadAssignedPorts(tile.id);
+        }, 80);
+      });
+
+      // Port type change -> populate port selector with Tom Select
+      portTypeSelect.addEventListener('change', function() {
+        var portType = this.value;
+
+        // Destroy existing Tom Select instance if any
+        if (portSelect.tomselect) {
+          portSelect.tomselect.destroy();
+        }
+
+        addBtn.disabled = true;
+
+        if (!portType) {
+          portSelect.innerHTML = '<option value="">-- Select port type first --</option>';
+          portSelect.disabled = true;
+          portSelect.classList.remove('api-select');
+          portSelect.classList.add('no-ts');
+          portSelect.removeAttribute('data-url');
+          portSelect.removeAttribute('data-static-params');
+          return;
+        }
+
+        var endpoint = DROP_API_ENDPOINTS[portType];
+        if (!endpoint) return;
+
+        var typeName = portType.split('.')[1];
+        var typeLabel = typeName === 'frontport' ? 'Front Port' : 'Rear Port';
+        portSelect.innerHTML = '<option value=""></option>';
+        portSelect.disabled = false;
+        portSelect.setAttribute('data-url', endpoint);
+        portSelect.setAttribute('placeholder', 'Search and select a ' + typeLabel + '...');
+        portSelect.setAttribute('data-static-params',
+          JSON.stringify([{queryParam: 'site_id', queryValue: [String(siteId)]}]));
+
+        portSelect.classList.remove('no-ts');
+        portSelect.classList.remove('tomselected');
+        portSelect.classList.add('api-select');
+
+        document.dispatchEvent(new Event('htmx:afterSettle'));
+
+        var ts = portSelect.tomselect;
+        if (ts) {
+          var contextSection = document.querySelector('.sidebar-context-section');
+          var sidebar = document.querySelector('.floorplan-sidebar');
+          ts.on('dropdown_open', function() {
+            if (contextSection) contextSection.style.overflow = 'visible';
+            if (sidebar) sidebar.style.overflow = 'visible';
+            // Force dropdown to open upward
+            var dd = ts.dropdown;
+            dd.style.setProperty('top', 'auto', 'important');
+            dd.style.setProperty('bottom', '100%', 'important');
+          });
+          ts.on('dropdown_close', function() {
+            if (contextSection) contextSection.style.overflow = '';
+            if (sidebar) sidebar.style.overflow = '';
+          });
+        }
+      });
+
+      // Add port assignment
+      addBtn.addEventListener('click', function() {
+        var detailPanel = document.getElementById('tile-detail-panel');
+        var tileId = detailPanel ? detailPanel.dataset.selectedTileId : null;
+        if (!tileId) return;
+
+        var portType = portTypeSelect.value;
+        var portId = parseInt(portSelect.value, 10);
+        if (!portType || !portId) return;
+
+        statusEl.textContent = 'Adding...';
+        addBtn.disabled = true;
+
+        fetch(assignmentApiUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
+          body: JSON.stringify({ tile: parseInt(tileId), port_type: portType, port_id: portId })
+        })
+        .then(function(r) {
+          if (r.ok) return r.json();
+          return r.json().then(function(e) { throw new Error(JSON.stringify(e)); });
+        })
+        .then(function() {
+          statusEl.textContent = 'Added!';
+          statusEl.className = 'small text-success ms-1';
+          addBtn.disabled = false;
+          // Update tile's port count in viewer
+          var viewer = window.floorplanViewer;
+          if (viewer) {
+            for (var i = 0; i < viewer.tiles.length; i++) {
+              if (viewer.tiles[i].id === parseInt(tileId)) {
+                viewer.tiles[i].drop_port_count = (viewer.tiles[i].drop_port_count || 0) + 1;
+                break;
+              }
+            }
+            viewer.render();
+          }
+          // Refresh port list after a brief delay to ensure DB commit
+          setTimeout(function() { loadAssignedPorts(tileId); }, 200);
+          setTimeout(function() { statusEl.textContent = ''; statusEl.className = 'small text-muted ms-1'; }, 2000);
+        })
+        .catch(function(err) {
+          statusEl.textContent = 'Error!';
+          statusEl.className = 'small text-danger ms-1';
+          addBtn.disabled = false;
+          console.error('Drop port add error:', err.message);
+          // Still try to reload ports - the add may have succeeded even if response parsing failed
+          setTimeout(function() { loadAssignedPorts(tileId); }, 500);
+          setTimeout(function() { statusEl.textContent = ''; statusEl.className = 'small text-muted ms-1'; }, 3000);
+        });
+      });
+
+      // Load and display assigned ports
+      function loadAssignedPorts(tileId) {
+        fetch(assignmentApiUrl + '?tile_id=' + tileId)
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            var results = data.results || [];
+            var html = '';
+            for (var i = 0; i < results.length; i++) {
+              var a = results[i];
+              var portName = a.port ? (a.port.display || ('Port #' + a.port_id)) : ('Port #' + a.port_id);
+              var portTypeBadge = a.port_type === 'dcim.frontport'
+                ? '<span class="badge bg-primary text-white me-1">FP</span>'
+                : '<span class="badge bg-info text-white me-1">RP</span>';
+              html += '<div class="d-flex align-items-center gap-1 mb-1">';
+              html += portTypeBadge;
+              html += '<span class="small flex-grow-1">' + portName + '</span>';
+              html += '<button class="btn btn-sm btn-outline-danger px-1 remove-drop-port" data-id="' + a.id + '" title="Remove">';
+              html += '<i class="mdi mdi-close"></i></button></div>';
+            }
+            portListEl.innerHTML = html || '<span class="text-muted small">No ports assigned</span>';
+            // Attach remove handlers
+            var removeBtns = portListEl.querySelectorAll('.remove-drop-port');
+            for (var j = 0; j < removeBtns.length; j++) {
+              removeBtns[j].addEventListener('click', (function(btn) {
+                return function() {
+                  var assignId = btn.getAttribute('data-id');
+                  fetch(assignmentApiUrl + assignId + '/', {
+                    method: 'DELETE',
+                    headers: { 'X-CSRFToken': csrfToken }
+                  }).then(function() {
+                    loadAssignedPorts(tileId);
+                    // Update tile's port count in viewer
+                    var viewer = window.floorplanViewer;
+                    if (viewer) {
+                      for (var k = 0; k < viewer.tiles.length; k++) {
+                        if (viewer.tiles[k].id === parseInt(tileId)) {
+                          viewer.tiles[k].drop_port_count = Math.max(0, (viewer.tiles[k].drop_port_count || 1) - 1);
+                          break;
+                        }
+                      }
+                      viewer.render();
+                    }
+                  });
+                };
+              })(removeBtns[j]));
+            }
+          });
+      }
     })();
 
     // Floor Plan linking logic (for floorplan_link tiles)

--- a/netbox_map/templates/netbox_map/floorplantile.html
+++ b/netbox_map/templates/netbox_map/floorplantile.html
@@ -39,6 +39,18 @@
               {% endif %}
             </td>
           </tr>
+          {% if object.tile_type == 'drop' %}
+          <tr>
+            <th scope="row">{% trans "Assigned Ports" %}</th>
+            <td>
+              {% for pa in object.port_assignments.all %}
+                {{ pa.port }}<br>
+              {% empty %}
+                <span class="text-muted">&mdash;</span>
+              {% endfor %}
+            </td>
+          </tr>
+          {% endif %}
           <tr>
             <th scope="row">{% trans "Label" %}</th>
             <td>{{ object.label|placeholder }}</td>

--- a/netbox_map/urls.py
+++ b/netbox_map/urls.py
@@ -21,6 +21,7 @@ urlpatterns = (
     path('sitemap/', views.SiteMapView.as_view(), name='sitemap'),
 
     # AJAX marker detail
+    path('marker-detail/drop/<int:tile_id>/', views.DropDetailView.as_view(), name='drop_detail'),
     path('marker-detail/<str:object_type>/<int:object_id>/', views.MarkerDetailView.as_view(), name='marker_detail'),
 
     # FloorPlan

--- a/netbox_map/views.py
+++ b/netbox_map/views.py
@@ -15,7 +15,7 @@ from utilities.views import ViewTab, register_model_view
 
 from . import filtersets, forms, tables
 from .choices import get_all_type_configs
-from .models import FloorPlan, FloorPlanTile, CustomMarkerType, LocationCoordinates, MapMarker, MapSettings
+from .models import FloorPlan, FloorPlanTile, CustomMarkerType, LocationCoordinates, MapMarker, MapSettings, TilePortAssignment
 
 
 #
@@ -303,7 +303,7 @@ def _serialize_tile(tile):
         except Exception:
             pass
 
-    return {
+    result = {
         'id': tile.pk,
         'x': tile.x_position,
         'y': tile.y_position,
@@ -333,6 +333,11 @@ def _serialize_tile(tile):
         ),
     }
 
+    if tile.tile_type == 'drop':
+        result['drop_port_count'] = getattr(tile, '_port_count', None) or tile.port_assignments.count()
+
+    return result
+
 
 #
 # FloorPlan views
@@ -352,7 +357,9 @@ class FloorPlanView(generic.ObjectView):
     queryset = FloorPlan.objects.all()
 
     def get_extra_context(self, request, instance):
-        tiles = instance.tiles.select_related('assigned_object_type', 'linked_floorplan').all()
+        tiles = instance.tiles.select_related(
+            'assigned_object_type', 'linked_floorplan'
+        ).annotate(_port_count=Count('port_assignments')).all()
         tile_data = [_serialize_tile(tile) for tile in tiles]
         return {
             'tile_data_json': json.dumps(tile_data),
@@ -402,7 +409,9 @@ class FloorPlanVisualizationView(generic.ObjectView):
     )
 
     def get_extra_context(self, request, instance):
-        tiles = instance.tiles.select_related('assigned_object_type', 'linked_floorplan').all()
+        tiles = instance.tiles.select_related(
+            'assigned_object_type', 'linked_floorplan'
+        ).annotate(_port_count=Count('port_assignments')).all()
         tile_data = [_serialize_tile(tile) for tile in tiles]
 
         site_floorplans = list(FloorPlan.objects.filter(
@@ -849,6 +858,45 @@ class MarkerDetailView(LoginRequiredMixin, View):
         except Exception:
             pass
         return result
+
+
+#
+# AJAX Drop Detail endpoint
+#
+
+class DropDetailView(LoginRequiredMixin, View):
+    """AJAX endpoint returning cable traces for all ports assigned to a drop tile."""
+
+    def get(self, request, tile_id):
+        try:
+            tile = FloorPlanTile.objects.get(pk=tile_id, tile_type='drop')
+        except FloorPlanTile.DoesNotExist:
+            return JsonResponse({'error': 'Drop tile not found'}, status=404)
+
+        assignments = tile.port_assignments.select_related('port_type').all()
+
+        # Reuse MarkerDetailView's trace methods
+        marker_view = MarkerDetailView()
+
+        interfaces = []
+        for assignment in assignments:
+            port = assignment.port
+            if port is None:
+                continue
+            port_type = assignment.port_type.model  # 'frontport' or 'rearport'
+            try:
+                traces = marker_view._get_cable_traces(port, port_type)
+                for trace in traces:
+                    interfaces.append(trace)
+            except Exception:
+                pass
+
+        return JsonResponse({
+            'standard_fields': [],
+            'mac_address': None,
+            'custom_fields': [],
+            'interfaces': interfaces,
+        })
 
 
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-map"
-version = "0.4.4"
+version = "0.5.0"
 description = "Interactive floor plan visualization for NetBox sites"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- New **drop** built-in tile type representing network wall plates/faceplates with multiple keystone jacks
- New `TilePortAssignment` model for assigning multiple front/rear ports to a single drop tile
- Drop detail AJAX endpoint with cable trace support for all assigned ports
- Drop port management panel in edit mode (add/remove ports via API)
- Cable trace popover support for drop tiles (simple and full modes)
- Optimized port assignment API with `GenericPrefetch` for batch loading
- Default popover config for drop tiles: label + cable trace

Closes #11