### PR TITLE
Fix drop cable trace direction

### DIFF
--- a/netbox_map/__init__.py
+++ b/netbox_map/__init__.py
@@ -6,7 +6,7 @@ class MapConfig(PluginConfig):
     verbose_name = 'NetBox Map'
     author = 'Christian Rose'
     description = 'Interactive floor plan visualization for NetBox sites'
-    version = '0.7.2'
+    version = '0.7.3'
     base_url = 'map'
     min_version = '4.5.0'
     default_settings = {

--- a/netbox_map/views.py
+++ b/netbox_map/views.py
@@ -863,23 +863,29 @@ class MarkerDetailView(LoginRequiredMixin, View):
             except Exception:
                 pass
 
-            # Reverse peer hops (swap near_end/far_end) so path flows toward
-            # the clicked port's side of the patch panel.
-            reversed_peer = []
-            for hop in peer_hops:
-                reversed_peer.append({
-                    'cable': hop['cable'],
-                    'near_end': hop.get('far_end'),
-                    'far_end': hop.get('near_end'),
-                })
-            reversed_peer.reverse()
-
-            # Combine: for rearport the path is peer-side → own-side,
-            # for frontport it is own-side → peer-side reversed.
+            # Combine traces into a single end-to-end path.
             if object_type == 'rearport':
+                # peer = FrontPort trace (front side) — reverse it
+                reversed_peer = []
+                for hop in peer_hops:
+                    reversed_peer.append({
+                        'cable': hop['cable'],
+                        'near_end': hop.get('far_end'),
+                        'far_end': hop.get('near_end'),
+                    })
+                reversed_peer.reverse()
                 combined = reversed_peer + own_hops
             else:
-                combined = own_hops + reversed_peer
+                # own = FrontPort trace (front side) — reverse it
+                reversed_own = []
+                for hop in own_hops:
+                    reversed_own.append({
+                        'cable': hop['cable'],
+                        'near_end': hop.get('far_end'),
+                        'far_end': hop.get('near_end'),
+                    })
+                reversed_own.reverse()
+                combined = reversed_own + peer_hops
 
             if combined:
                 traces.append({

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-map"
-version = "0.7.2"
+version = "0.7.3"
 description = "Interactive floor plan visualization for NetBox sites"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Fix cable trace showing in wrong order when clicking a drop tile with a FrontPort assignment.

Bump to v0.7.3