### PR TITLE
Fix migration NodeNotFoundError (v0.9.2)

### DIFF
--- a/netbox_map/__init__.py
+++ b/netbox_map/__init__.py
@@ -6,7 +6,7 @@ class MapConfig(PluginConfig):
     verbose_name = 'NetBox Map'
     author = 'Christian Rose'
     description = 'Interactive floor plan visualization for NetBox sites'
-    version = '0.9.1'
+    version = '0.9.2'
     base_url = 'map'
     min_version = '4.5.0'
     default_settings = {

--- a/netbox_map/migrations/0016_topologysavedview.py
+++ b/netbox_map/migrations/0016_topologysavedview.py
@@ -1,0 +1,19 @@
+"""
+Placeholder migration — the actual table creation is in 0017.
+
+This file exists so that users who created merge migrations referencing
+'0016_topologysavedview' (from v0.9.0) don't get NodeNotFoundError.
+It does nothing — the real work is in 0017 with IF NOT EXISTS safety.
+"""
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('netbox_map', '0015_cablepath_cable_type'),
+    ]
+
+    operations = [
+        # No-op — 0017 handles the actual table creation
+    ]

--- a/netbox_map/migrations/0017_topologysavedview.py
+++ b/netbox_map/migrations/0017_topologysavedview.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ('dcim', '0001_initial'),
         ('extras', '0001_initial'),
-        ('netbox_map', '0015_cablepath_cable_type'),
+        ('netbox_map', '0016_topologysavedview'),
     ]
 
     operations = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-map"
-version = "0.9.1"
+version = "0.9.2"
 description = "Interactive floor plan visualization for NetBox sites"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
Fixes migration error for users who created merge migrations referencing the old `0016_topologysavedview`.

Restores `0016` as a no-op placeholder, keeps `0017` as the actual table creation with `IF NOT EXISTS`.

Closes #30

## Upgrade paths
- **Fresh install**: 0016 (no-op) → 0017 (creates table) ✓
- **v0.9.0 upgraders**: 0016 already applied → 0017 (IF NOT EXISTS, skips) ✓  
- **Users with merge migrations**: 0016 exists → merge → 0017 ✓