### PR TITLE
fix: floor plan PDF respects light theme (#41)

### DIFF
--- a/netbox_map/static/netbox_map/js/floorplan_pdf.js
+++ b/netbox_map/static/netbox_map/js/floorplan_pdf.js
@@ -74,9 +74,25 @@
         var renderScale = Math.min(scaleX, scaleY);
         offCtx.scale(renderScale, renderScale);
 
-        // Detect theme
-        var el = document.documentElement;
-        var isDark = !el || el.getAttribute('data-bs-theme') !== 'light';
+        // Detect theme — resolution order matches the renderer (issue #41):
+        //   1. data-bs-theme attribute on <html>
+        //   2. NetBox's localStorage 'netbox-color-mode'
+        //   3. prefers-color-scheme media query
+        //   4. Fallback: light (NetBox's own default)
+        var isDark = (function() {
+            var attr = document.documentElement && document.documentElement.getAttribute('data-bs-theme');
+            if (attr === 'dark') return true;
+            if (attr === 'light') return false;
+            try {
+                var stored = window.localStorage.getItem('netbox-color-mode');
+                if (stored === 'dark') return true;
+                if (stored === 'light') return false;
+            } catch (e) { /* localStorage may be blocked */ }
+            if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                return true;
+            }
+            return false;
+        })();
         var gridBg = isDark ? '#16192b' : '#dfe1e8';
         var gridLine = isDark ? 'rgba(255, 255, 255, 0.06)' : 'rgba(0, 0, 0, 0.08)';
         var gridLineImg = isDark ? 'rgba(255, 255, 255, 0.12)' : 'rgba(0, 0, 0, 0.15)';

--- a/netbox_map/static/netbox_map/js/floorplan_renderer.js
+++ b/netbox_map/static/netbox_map/js/floorplan_renderer.js
@@ -114,10 +114,31 @@
         ctx.closePath();
     };
 
-    /** Detect current NetBox theme (light vs dark). */
+    /** Detect current NetBox theme (light vs dark).
+     *
+     * Resolution order:
+     *   1. data-bs-theme on <html> ("dark"/"light") — set by NetBox's colorMode JS
+     *   2. NetBox's localStorage key 'netbox-color-mode'
+     *   3. window.matchMedia('(prefers-color-scheme: dark)')
+     *   4. Fallback: light (NetBox's own default when no preference is found)
+     *
+     * Previous logic defaulted to DARK when the attribute was missing,
+     * which caused the PDF to look dark even when the user was in light
+     * mode (issue #41).
+     */
     Renderer.prototype._detectTheme = function() {
-        var el = document.documentElement;
-        this._isDark = !el || el.getAttribute('data-bs-theme') !== 'light';
+        var attr = document.documentElement && document.documentElement.getAttribute('data-bs-theme');
+        if (attr === 'dark') { this._isDark = true; return; }
+        if (attr === 'light') { this._isDark = false; return; }
+        try {
+            var stored = window.localStorage.getItem('netbox-color-mode');
+            if (stored === 'dark') { this._isDark = true; return; }
+            if (stored === 'light') { this._isDark = false; return; }
+        } catch (e) { /* localStorage may be blocked */ }
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            this._isDark = true; return;
+        }
+        this._isDark = false;
     };
 
     /** Theme-aware canvas colors. */


### PR DESCRIPTION
Closes #41

The previous theme detection treated 'data-bs-theme attribute missing' as dark, so any moment where the attribute wasn't set yet (page loaded before NetBox's colorMode JS ran) rendered dark even for light-mode users.

New 4-tier resolution:
1. data-bs-theme on <html> ('dark' or 'light' — definitive)
2. localStorage 'netbox-color-mode' (NetBox's source of truth)
3. prefers-color-scheme media query
4. Fallback: light (matches NetBox's own default)

Same helper now used in floorplan_renderer.js and floorplan_pdf.js.