### PR TITLE
feat: topology filter by tag + include sub-locations/sub-roles (#35, #44)

### DIFF
--- a/netbox_map/forms.py
+++ b/netbox_map/forms.py
@@ -1236,6 +1236,23 @@ class TopologyFilterForm(forms.Form):
         required=False,
         label=_('Cable Type'),
     )
+    # #44 — Filter devices by tag
+    tag = forms.CharField(
+        required=False,
+        label=_('Tag (slug)'),
+        help_text=_('Comma-separated list of tag slugs to match. Devices with any of these tags are shown.'),
+    )
+    # #35 — Toggle to include MPTT descendants for hierarchical filters
+    include_sub_locations = forms.BooleanField(
+        required=False,
+        label=_('Include sub-locations'),
+        help_text=_('When a Location is selected, also include its descendants.'),
+    )
+    include_sub_roles = forms.BooleanField(
+        required=False,
+        label=_('Include sub-roles'),
+        help_text=_('When Device Role(s) are selected, also include their descendants.'),
+    )
 
 
 #

--- a/netbox_map/forms.py
+++ b/netbox_map/forms.py
@@ -26,8 +26,10 @@ from utilities.forms.fields import (
     DynamicModelChoiceField,
     DynamicModelMultipleChoiceField,
     SlugField,
+    TagFilterField,
 )
 from utilities.forms.rendering import FieldSet
+from utilities.forms.widgets import APISelect, APISelectMultiple
 
 from .choices import (
     ApplicationCriticalityChoices,
@@ -1208,40 +1210,42 @@ class TopologyFilterForm(forms.Form):
         queryset=Site.objects.all(),
         required=False,
         label=_('Site'),
+        widget=APISelect(attrs={'data-placeholder': _('Site')}),
     )
     tenant_id = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
         required=False,
         label=_('Tenant'),
+        widget=APISelect(attrs={'data-placeholder': _('Tenant')}),
     )
     location_id = DynamicModelChoiceField(
         queryset=Location.objects.all(),
         required=False,
         label=_('Location'),
         query_params={'site_id': '$site_id'},
+        widget=APISelect(attrs={'data-placeholder': _('Location')}),
     )
     rack_id = DynamicModelChoiceField(
         queryset=Rack.objects.all(),
         required=False,
         label=_('Rack'),
         query_params={'site_id': '$site_id', 'location_id': '$location_id'},
+        widget=APISelect(attrs={'data-placeholder': _('Rack')}),
     )
     role_id = DynamicModelMultipleChoiceField(
         queryset=DeviceRole.objects.all(),
         required=False,
         label=_('Device Role'),
+        widget=APISelectMultiple(attrs={'data-placeholder': _('Role')}),
     )
     cable_type = forms.ChoiceField(
-        choices=[('', '---------')] + list(CableTypeChoices),
+        choices=[('', _('Cable type'))] + list(CableTypeChoices),
         required=False,
         label=_('Cable Type'),
     )
-    # #44 — Filter devices by tag
-    tag = forms.CharField(
-        required=False,
-        label=_('Tag (slug)'),
-        help_text=_('Comma-separated list of tag slugs to match. Devices with any of these tags are shown.'),
-    )
+    # #44 — Filter devices by tag (multi-select dropdown of tags actually
+    # used on Device, instead of a free-text slug input).
+    tag = TagFilterField(model=Device)
     # #35 — Toggle to include MPTT descendants for hierarchical filters
     include_sub_locations = forms.BooleanField(
         required=False,
@@ -1253,6 +1257,12 @@ class TopologyFilterForm(forms.Form):
         label=_('Include sub-roles'),
         help_text=_('When Device Role(s) are selected, also include their descendants.'),
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # TagFilterField doesn't accept a custom widget kwarg, so set
+        # its placeholder here so it matches the other filter dropdowns.
+        self.fields['tag'].widget.attrs['data-placeholder'] = _('Tag')
 
 
 #

--- a/netbox_map/static/netbox_map/css/topology.css
+++ b/netbox_map/static/netbox_map/css/topology.css
@@ -18,6 +18,14 @@
     flex-wrap: wrap;
 }
 
+/* Two-row layout: filters on top, actions below.
+ * Subtle separator between them. */
+.topo-toolbar-row-actions {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--fp-border-light, rgba(0, 0, 0, 0.06));
+}
+
 .topo-toolbar-group {
     display: flex;
     align-items: center;
@@ -27,6 +35,10 @@
 .topo-toolbar-filters {
     flex: 1;
     min-width: 0;
+    /* Allow filter inputs and toggle pills to wrap to a second visual
+     * row when the toolbar runs out of horizontal space (#35/#44). */
+    flex-wrap: wrap;
+    row-gap: 6px;
 }
 
 .topo-toolbar-label {
@@ -36,56 +48,61 @@
     flex-shrink: 0;
 }
 
-/* Toggle pill for "Sub-locations" / "Sub-roles" (#35) */
-.topo-toolbar-toggle {
+/* "Sub-locations" / "Sub-roles" toggles in the topology toolbar (#35).
+ * Plain Bootstrap form-check checkboxes — no custom styling so they
+ * match every other checkbox in NetBox. */
+.topo-toggle-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+    margin: 0 8px;
+    white-space: nowrap;
+}
+.topo-toggle-group .form-check {
+    margin: 0;
+    padding-left: 1.5em;
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    font-size: 12px;
-    color: var(--fp-text-muted);
+}
+.topo-toggle-group .form-check-label {
     cursor: pointer;
-    padding: 4px 8px;
-    border-radius: 4px;
-    border: 1px solid transparent;
     user-select: none;
-    white-space: nowrap;
-    flex-shrink: 0;
 }
-.topo-toolbar-toggle:hover {
-    background: rgba(0, 0, 0, 0.04);
-}
-[data-bs-theme="dark"] .topo-toolbar-toggle:hover {
-    background: rgba(255, 255, 255, 0.05);
-}
-.topo-toolbar-toggle input[type="checkbox"] {
-    margin: 0;
-    cursor: pointer;
-}
-.topo-toolbar-toggle:has(input:checked) {
-    color: var(--fp-text);
-    border-color: var(--fp-toggle-active-border, rgba(13, 110, 253, 0.3));
-    background: var(--fp-toggle-active-bg, rgba(13, 110, 253, 0.1));
+.topo-toggle-group .form-check-label .mdi {
+    margin-right: 2px;
 }
 
 .topo-filter-field {
-    width: 145px;
-    min-width: 90px;
+    /* Auto-size to the selected value, but keep a sensible floor so
+     * empty fields still show their placeholder, and a ceiling so a
+     * single very long value can't push everything else off-screen. */
+    width: auto;
+    min-width: 130px;
+    max-width: 280px;
+    flex-shrink: 0;
 }
 
 .topo-filter-sm {
-    width: 120px;
+    min-width: 110px;
 }
 
 .topo-filter-field select,
 .topo-filter-field .ts-wrapper {
     font-size: 12px !important;
     min-height: 28px !important;
+    width: auto !important;
+    min-width: 100%;
 }
 
 .topo-filter-field .ts-wrapper .ts-control {
     min-height: 26px !important;
     padding: 0 8px !important;
     font-size: 12px !important;
+    /* Let selected items wrap inside the control so the field grows
+     * vertically before it gets cut off. */
+    flex-wrap: wrap;
 }
 
 .topo-toolbar-info {

--- a/netbox_map/static/netbox_map/css/topology.css
+++ b/netbox_map/static/netbox_map/css/topology.css
@@ -36,6 +36,37 @@
     flex-shrink: 0;
 }
 
+/* Toggle pill for "Sub-locations" / "Sub-roles" (#35) */
+.topo-toolbar-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--fp-text-muted);
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    border: 1px solid transparent;
+    user-select: none;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+.topo-toolbar-toggle:hover {
+    background: rgba(0, 0, 0, 0.04);
+}
+[data-bs-theme="dark"] .topo-toolbar-toggle:hover {
+    background: rgba(255, 255, 255, 0.05);
+}
+.topo-toolbar-toggle input[type="checkbox"] {
+    margin: 0;
+    cursor: pointer;
+}
+.topo-toolbar-toggle:has(input:checked) {
+    color: var(--fp-text);
+    border-color: var(--fp-toggle-active-border, rgba(13, 110, 253, 0.3));
+    background: var(--fp-toggle-active-bg, rgba(13, 110, 253, 0.1));
+}
+
 .topo-filter-field {
     width: 145px;
     min-width: 90px;

--- a/netbox_map/templates/netbox_map/topology.html
+++ b/netbox_map/templates/netbox_map/topology.html
@@ -18,8 +18,8 @@
 
 {# ===== Toolbar ===== #}
 <div class="topo-toolbar">
-  {# Row 1: Filters + Actions #}
-  <form method="get" action="" id="topology-filter-form" class="topo-toolbar-row">
+  {# Row 1: Filters only #}
+  <form method="get" action="" id="topology-filter-form" class="topo-toolbar-row topo-toolbar-row-filters">
     <div class="topo-toolbar-group topo-toolbar-filters">
       <label class="topo-toolbar-label"><i class="mdi mdi-filter-variant"></i></label>
       <div class="topo-filter-field">{{ filter_form.site_id }}</div>
@@ -30,20 +30,31 @@
         {{ filter_form.tag }}
       </div>
       <div class="d-none">{{ filter_form.tenant_id }}{{ filter_form.rack_id }}</div>
-      <label class="topo-toolbar-toggle" title="{% trans 'Include sub-locations' %}">
-        {{ filter_form.include_sub_locations }}
-        <span><i class="mdi mdi-file-tree-outline"></i> {% trans 'Sub-locations' %}</span>
-      </label>
-      <label class="topo-toolbar-toggle" title="{% trans 'Include sub-roles' %}">
-        {{ filter_form.include_sub_roles }}
-        <span><i class="mdi mdi-account-tree-outline"></i> {% trans 'Sub-roles' %}</span>
-      </label>
+      <div class="topo-toggle-group">
+        <div class="form-check" title="{% trans 'Include sub-locations (children of selected Location)' %}">
+          <input type="checkbox" class="form-check-input" id="id_include_sub_locations"
+                 name="include_sub_locations" {% if filter_form.include_sub_locations.value %}checked{% endif %}>
+          <label class="form-check-label small text-muted" for="id_include_sub_locations">
+            <i class="mdi mdi-file-tree-outline"></i> sub-locations
+          </label>
+        </div>
+        <div class="form-check" title="{% trans 'Include sub-roles (children of selected Role)' %}">
+          <input type="checkbox" class="form-check-input" id="id_include_sub_roles"
+                 name="include_sub_roles" {% if filter_form.include_sub_roles.value %}checked{% endif %}>
+          <label class="form-check-label small text-muted" for="id_include_sub_roles">
+            <i class="mdi mdi-account-tree-outline"></i> sub-roles
+          </label>
+        </div>
+      </div>
       <button type="submit" class="topo-btn topo-btn-primary">{% trans "Apply" %}</button>
       {% if active_filters %}
       <a href="?" class="topo-btn topo-btn-danger" title="{% trans 'Clear filters' %}"><i class="mdi mdi-close"></i></a>
       {% endif %}
     </div>
+  </form>
 
+  {# Row 2: Actions + stats #}
+  <div class="topo-toolbar-row topo-toolbar-row-actions">
     <div class="topo-toolbar-group topo-toolbar-info">
       <span class="topo-stat" id="topology-stats">
         <span id="stat-nodes">0</span> {% trans "devices" %}
@@ -158,7 +169,7 @@
       {# PDF Export #}
       <button id="topo-export-pdf" class="topo-btn" type="button" title="{% trans 'Export PDF' %}"><i class="mdi mdi-download"></i></button>
     </div>
-  </form>
+  </div>
 </div>
 
 {# ===== Main layout: SVG graph + sidebar ===== #}

--- a/netbox_map/templates/netbox_map/topology.html
+++ b/netbox_map/templates/netbox_map/topology.html
@@ -26,7 +26,18 @@
       <div class="topo-filter-field">{{ filter_form.location_id }}</div>
       <div class="topo-filter-field topo-filter-sm">{{ filter_form.role_id }}</div>
       <div class="topo-filter-field topo-filter-sm">{{ filter_form.cable_type }}</div>
+      <div class="topo-filter-field topo-filter-sm">
+        {{ filter_form.tag }}
+      </div>
       <div class="d-none">{{ filter_form.tenant_id }}{{ filter_form.rack_id }}</div>
+      <label class="topo-toolbar-toggle" title="{% trans 'Include sub-locations' %}">
+        {{ filter_form.include_sub_locations }}
+        <span><i class="mdi mdi-file-tree-outline"></i> {% trans 'Sub-locations' %}</span>
+      </label>
+      <label class="topo-toolbar-toggle" title="{% trans 'Include sub-roles' %}">
+        {{ filter_form.include_sub_roles }}
+        <span><i class="mdi mdi-account-tree-outline"></i> {% trans 'Sub-roles' %}</span>
+      </label>
       <button type="submit" class="topo-btn topo-btn-primary">{% trans "Apply" %}</button>
       {% if active_filters %}
       <a href="?" class="topo-btn topo-btn-danger" title="{% trans 'Clear filters' %}"><i class="mdi mdi-close"></i></a>

--- a/netbox_map/views.py
+++ b/netbox_map/views.py
@@ -202,8 +202,10 @@ class TopologyDataView(LoginRequiredMixin, View):
                     tag_slugs.append(piece)
         # Include MPTT descendants for hierarchical filters (#35).
         # Truthy values: '1', 'true', 'yes', 'on'.
+
         def _truthy(v):
             return str(v).lower() in ('1', 'true', 'yes', 'on')
+
         include_sub_locations = _truthy(request.GET.get('include_sub_locations', ''))
         include_sub_roles = _truthy(request.GET.get('include_sub_roles', ''))
 

--- a/netbox_map/views.py
+++ b/netbox_map/views.py
@@ -46,14 +46,18 @@ class TopologyView(LoginRequiredMixin, View):
         filter_form = forms.TopologyFilterForm(data=request.GET or None)
 
         initial_filters = {}
-        for key in ('site_id', 'tenant_id', 'location_id', 'rack_id', 'cable_type', 'device_ids'):
+        for key in ('site_id', 'tenant_id', 'location_id', 'rack_id', 'cable_type', 'device_ids',
+                    'include_sub_locations', 'include_sub_roles'):
             val = request.GET.get(key)
             if val:
                 initial_filters[key] = val
-        # role_id supports multiple values
+        # role_id and tag support multiple values
         role_ids = request.GET.getlist('role_id')
         if role_ids:
             initial_filters['role_id'] = role_ids
+        tag_slugs = request.GET.getlist('tag')
+        if tag_slugs:
+            initial_filters['tag'] = tag_slugs
 
         # App topology params
         topology_mode = request.GET.get('mode', '')
@@ -186,6 +190,22 @@ class TopologyDataView(LoginRequiredMixin, View):
         role_ids = request.GET.getlist('role_id')
         cable_type = request.GET.get('cable_type')
         device_ids_param = request.GET.get('device_ids')
+        # Tag filter (#44) — match any of the supplied tag slugs.
+        # Accepts both repeated ?tag=a&tag=b and a single comma-separated
+        # ?tag=a,b form (the toolbar input submits the latter).
+        raw_tags = request.GET.getlist('tag')
+        tag_slugs = []
+        for entry in raw_tags:
+            for piece in entry.split(','):
+                piece = piece.strip()
+                if piece:
+                    tag_slugs.append(piece)
+        # Include MPTT descendants for hierarchical filters (#35).
+        # Truthy values: '1', 'true', 'yes', 'on'.
+        def _truthy(v):
+            return str(v).lower() in ('1', 'true', 'yes', 'on')
+        include_sub_locations = _truthy(request.GET.get('include_sub_locations', ''))
+        include_sub_roles = _truthy(request.GET.get('include_sub_roles', ''))
 
         devices = Device.objects.select_related(
             'device_type__manufacturer', 'role', 'site', 'location',
@@ -203,14 +223,41 @@ class TopologyDataView(LoginRequiredMixin, View):
             if tenant_id:
                 devices = devices.filter(tenant_id=tenant_id)
             if location_id:
-                devices = devices.filter(location_id=location_id)
+                # #35: optionally include all descendant locations.
+                # dcim.Location is an MPTT model.
+                if include_sub_locations:
+                    from dcim.models import Location
+                    try:
+                        loc = Location.objects.get(pk=location_id)
+                        loc_ids = list(loc.get_descendants(include_self=True).values_list('pk', flat=True))
+                        devices = devices.filter(location_id__in=loc_ids)
+                    except Location.DoesNotExist:
+                        devices = devices.filter(location_id=location_id)
+                else:
+                    devices = devices.filter(location_id=location_id)
             if rack_id:
                 devices = devices.filter(rack_id=rack_id)
             if role_ids:
-                devices = devices.filter(role_id__in=role_ids)
+                # #35: optionally include all descendant roles.
+                # dcim.DeviceRole is an MPTT model.
+                if include_sub_roles:
+                    from dcim.models import DeviceRole
+                    expanded = set()
+                    for rid in role_ids:
+                        try:
+                            r = DeviceRole.objects.get(pk=rid)
+                            expanded.update(r.get_descendants(include_self=True).values_list('pk', flat=True))
+                        except DeviceRole.DoesNotExist:
+                            expanded.add(int(rid))
+                    devices = devices.filter(role_id__in=list(expanded))
+                else:
+                    devices = devices.filter(role_id__in=role_ids)
+            if tag_slugs:
+                # #44: filter to devices that carry any of the supplied tag slugs
+                devices = devices.filter(tags__slug__in=tag_slugs).distinct()
 
             # Require at least one filter when not using device_ids
-            if not any([site_id, tenant_id, location_id, rack_id, role_ids]):
+            if not any([site_id, tenant_id, location_id, rack_id, role_ids, tag_slugs]):
                 return JsonResponse({'nodes': [], 'edges': [], 'stats': {'node_count': 0, 'edge_count': 0}})
 
         device_map = {}


### PR DESCRIPTION
## Summary

Two new filtering features for the Network Topology view:

- **#44 — Filter by tag**: New multi-select dropdown of tags actually used on `Device`. Pick one or more tags to scope the topology to those devices.
- **#35 — Include sub-locations / sub-roles**: Two toggles next to the filter inputs. When a Location is selected and "sub-locations" is checked, all descendant locations are included (MPTT). Same for Device Role.

## UI polish (toolbar)

- Toolbar split into two rows: filters on top, actions (Views, Save, zoom, mode toggles, etc.) below — no more overlap when several filters are active.
- Filter dropdowns auto-scale to their selected value (130–280px) so long location/site names no longer wrap mid-word.
- Toggles use NetBox's standard `form-check` checkboxes for visual consistency.
- Placeholders show just "Site", "Location", "Role" etc.

## Backend

- `TopologyDataView` accepts `?tag=<slug>` (repeat or comma-separated) and `?include_sub_locations`/`?include_sub_roles` query params.
- MPTT `get_descendants(include_self=True)` powers the sub-location and sub-role filters.

Closes #35
Closes #44

## Test plan
- [x] Open Network Topology, pick a Site → only that Site's devices show.
- [x] Pick a Location with children → check "sub-locations" → child-location devices appear too.
- [x] Pick one or more Roles → only those roles show. Toggle "sub-roles" with a parent role to include children.
- [x] Pick one or more Tags from the new dropdown → only tagged devices show.
- [x] Toolbar wraps cleanly on narrower windows (no overlap).
- [x] Saving and restoring a saved view preserves all of the above filters.