### PR TITLE
Fix topology layout collapsing to a single column/line

### DIFF
--- a/netbox_map/static/netbox_map/js/topology_renderer.js
+++ b/netbox_map/static/netbox_map/js/topology_renderer.js
@@ -61,8 +61,16 @@
             return -1;
         }
 
-        // Check if any role hints match
-        var hasHints = nodeData.some(function(n) { return roleHint(n.role_slug) >= 0; });
+        // Only trust role hints when they cover a meaningful share of the graph.
+        // A single incidentally-matching role (e.g. one device with role "Server"
+        // among otherwise unrelated custom role names) used to be enough to flip
+        // the *entire* graph into hint mode, even though only that one device had
+        // a real hint. Everything else fell through the unassigned-node pass below
+        // with no resolved neighbor yet and collapsed onto the same default layer,
+        // producing a single-column layout for graphs that don't actually use this
+        // hint vocabulary.
+        var hintedCount = nodeData.filter(function(n) { return roleHint(n.role_slug) >= 0; }).length;
+        var hasHints = nodeData.length > 0 && (hintedCount / nodeData.length) >= 0.15;
 
         if (hasHints) {
             // Use role hints — group by hint value, unmatched roles get assigned
@@ -97,45 +105,62 @@
             return layers;
         }
 
-        // No role hints — use pure BFS from lowest-degree nodes
-        var sorted = nodeData.slice().sort(function(a, b) {
-            return (degree[a.id] || 0) - (degree[b.id] || 0);
-        });
-
-        // BFS from the node with fewest connections
+        // No role hints — BFS from the lowest-degree node of each connected
+        // component independently, rather than once from a single global
+        // root. Real device graphs are rarely one connected mesh — they're
+        // typically several independent stars (one per switch/gateway) plus
+        // a large number of fully isolated devices (unused ports, spare
+        // equipment). A single BFS run only ever explores the one component
+        // its root belongs to; everything else used to be dumped into one
+        // shared fallback layer, collapsing the whole diagram into a single
+        // column whenever most devices weren't part of that one component.
+        // Layering each component on its own (all restarting at layer 0)
+        // keeps every component's own depth/hierarchy intact while still
+        // letting independent components share layer columns as siblings.
         var visited = {};
         var layers = {};
-        var queue = [];
 
-        // Start from lowest-degree node
-        if (sorted.length > 0) {
-            var root = sorted[0];
-            queue.push({ node: root, level: 0 });
-            visited[root.id] = true;
-        }
+        nodeData.forEach(function(seedNode) {
+            if (visited[seedNode.id]) return;
 
-        while (queue.length > 0) {
-            var item = queue.shift();
-            var lvl = item.level;
-            if (!layers[lvl]) layers[lvl] = [];
-            layers[lvl].push(item.node);
-            item.node._layer = lvl;
+            // Collect this connected component.
+            var component = [];
+            var componentVisited = {};
+            var stack = [seedNode.id];
+            componentVisited[seedNode.id] = true;
+            while (stack.length > 0) {
+                var id = stack.pop();
+                component.push(nodeIds[id]);
+                (adj[id] || []).forEach(function(nid) {
+                    if (!componentVisited[nid] && nodeIds[nid]) {
+                        componentVisited[nid] = true;
+                        stack.push(nid);
+                    }
+                });
+            }
+            component.forEach(function(n) { visited[n.id] = true; });
 
-            (adj[item.node.id] || []).forEach(function(nid) {
-                if (!visited[nid] && nodeIds[nid]) {
-                    visited[nid] = true;
-                    queue.push({ node: nodeIds[nid], level: lvl + 1 });
-                }
+            // BFS-layer this component from its own lowest-degree node.
+            var compSorted = component.slice().sort(function(a, b) {
+                return (degree[a.id] || 0) - (degree[b.id] || 0);
             });
-        }
+            var localVisited = {};
+            var queue = [{ node: compSorted[0], level: 0 }];
+            localVisited[compSorted[0].id] = true;
 
-        // Handle disconnected nodes
-        nodeData.forEach(function(n) {
-            if (!visited[n.id]) {
-                var maxLayer = Object.keys(layers).length;
-                if (!layers[maxLayer]) layers[maxLayer] = [];
-                layers[maxLayer].push(n);
-                n._layer = maxLayer;
+            while (queue.length > 0) {
+                var item = queue.shift();
+                var lvl = item.level;
+                if (!layers[lvl]) layers[lvl] = [];
+                layers[lvl].push(item.node);
+                item.node._layer = lvl;
+
+                (adj[item.node.id] || []).forEach(function(nid) {
+                    if (!localVisited[nid] && nodeIds[nid]) {
+                        localVisited[nid] = true;
+                        queue.push({ node: nodeIds[nid], level: lvl + 1 });
+                    }
+                });
             }
         });
 

--- a/netbox_map/static/netbox_map/js/topology_renderer.js
+++ b/netbox_map/static/netbox_map/js/topology_renderer.js
@@ -1785,7 +1785,31 @@
     Renderer.prototype.zoomIn = function() { this.svg.transition().duration(300).call(this.zoom.scaleBy, 1.3); };
     Renderer.prototype.zoomOut = function() { this.svg.transition().duration(300).call(this.zoom.scaleBy, 0.7); };
     Renderer.prototype.resize = function() { this._updateSize(); };
-    Renderer.prototype.switchView = function(m) { this.state.viewMode = m; this.render(this.state.nodes, this.state.edges, true); };
+    Renderer.prototype.switchView = function(m) {
+        if (this.state.viewMode === m) return;
+        this.state.viewMode = m;
+
+        // Stencil (card) view and Node (circle) view use fundamentally different
+        // layout strategies — hierarchical columns vs. a force simulation — but
+        // share the same underlying node objects for x/y. Carrying one view's
+        // positions over as the other's starting point produces nonsense: e.g.
+        // Node View's force simulation inheriting Stencil View's single-file
+        // column as its initial shape, which repulsion alone can't break out of.
+        // Clear non-pinned positions on every mode switch — same thing the
+        // "Reset Layout" button does — so each view always computes its own
+        // fresh layout instead of inheriting the other's.
+        var pinLayout = {};
+        this.state.nodes.forEach(function(n) {
+            if (n._pinned && n.x !== undefined) {
+                pinLayout[n.id] = { x: n.x, y: n.y };
+            } else {
+                delete n.x; delete n.y;
+            }
+        });
+        this.state.savedLayout = pinLayout;
+
+        this.render(this.state.nodes, this.state.edges, true);
+    };
     Renderer.prototype.switchLayout = function() { this.render(this.state.nodes, this.state.edges, true); };
     Renderer.prototype.switchCableStyle = function(style) { this.state.cableStyle = style; this.render(this.state.nodes, this.state.edges, true); };
 


### PR DESCRIPTION
## Summary

`computeLayers()` in `topology_renderer.js` tries to infer a network hierarchy by matching device role slugs against a hardcoded set of hints (`router`, `core`, `access`, `server`, etc). A single incidentally-matching role — e.g. one device with role "Server" among an otherwise unrelated set of custom role names — was enough to flip the *entire* graph into hint mode, even though only that one device had a real hint. Every other device fell through a single-pass neighbor-averaging loop that, lacking a resolved neighbor, defaulted to the same layer as that one hint, collapsing the whole diagram onto a single column.

Repro case: 609 devices, one of which has role "Server". That one match collapsed all 609 nodes onto a single layer (1 column) in Stencil/Card view.

Separately, the non-hint fallback path only ever BFS-explored from a single global root, dumping every other connected component (and any fully isolated device) into one shared fallback layer — the same collapse via a different path, for graphs that aren't one connected mesh (e.g. several independent switch stars plus many unwired spare devices — typical DCIM data).

Finally, Node (circle) view and Stencil (card) view share the same underlying node objects for x/y, but use completely different layout strategies (force simulation vs. hierarchical columns). Switching between them used to carry one view's computed positions over as the other's starting point — so Node View's force simulation would inherit Stencil View's collapsed single-file column as its initial shape, and stay collapsed since repulsion alone doesn't break a degenerate 1-D starting condition apart.

## Changes

1. `computeLayers()`: only trust role hints once they cover a meaningful share of the graph (>=15%), otherwise fall back to connectivity-based layering.
2. `computeLayers()`: layer each connected component independently (BFS per-component, each restarting at layer 0) instead of a single global BFS run whose leftover nodes all collapse into one fallback layer.
3. `switchView()`: clear non-pinned node positions on every mode switch (mirrors what the existing "Reset Layout" button does), so each view always computes its own fresh layout instead of inheriting the other's.

## Test plan

- Verified against a real 609-device / 189-cable topology extracted via the NetBox API: before the fix, all 609 nodes landed in 1 layer; after, they spread across 7 layers with a 420/16/21/42/53/35/22 split matching the actual cable hierarchy.
- Confirmed in a live NetBox 4.6 instance: Stencil view no longer collapses to one column, and switching to Node view no longer inherits a degenerate starting shape.