### PR TITLE
Add missing cable labels in the topology view

### DIFF
--- a/netbox_map/static/netbox_map/js/topology_pdf.js
+++ b/netbox_map/static/netbox_map/js/topology_pdf.js
@@ -335,7 +335,7 @@
             if (!sp || !tp) return;
 
             // Short label: just #ID + abbreviated type
-            var label = '#' + edge.cable_id;
+            var label = edge.cable_label || ('#' + edge.cable_id);
             if (edge.cable_type) {
                 var ct = edge.cable_type;
                 ct = ct.replace('Single-mode Fiber', 'SMF').replace('Multimode Fiber', 'MMF');

--- a/netbox_map/static/netbox_map/js/topology_renderer.js
+++ b/netbox_map/static/netbox_map/js/topology_renderer.js
@@ -802,7 +802,7 @@
                 .attr('href', '#cable-label-path-' + d.cable_id)
                 .attr('startOffset', '50%')
                 .attr('text-anchor', 'middle');
-            tp.append('tspan').attr('class', 'cable-label-id').text('#' + d.cable_id);
+            tp.append('tspan').attr('class', 'cable-label-id').text(d.cable_label || ('#' + d.cable_id));
             if (d.cable_type) {
                 tp.append('tspan').attr('dx', 5).text(d.cable_type);
             }


### PR DESCRIPTION
I noticed that the topology view doesn't correctly show the cable labels.
The fix was simply adding the missing variable to the web and PDF renderer (the ID remains as a fallback).
Fixes #72 